### PR TITLE
Import with statement from __future__.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 from setuptools import setup, find_packages
 from simple_sso import __version__ as version
 import os

--- a/simple_sso/test_utils/context_managers.py
+++ b/simple_sso/test_utils/context_managers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 from django.conf import settings
 
 class NULL:

--- a/simple_sso/tests.py
+++ b/simple_sso/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
 from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.models import User


### PR DESCRIPTION
Deployment server where we would like to use this library is currently running Python version which does not support `with` statement without it being imported from the `__future__`.
